### PR TITLE
feat: Add token authentication for Tahmo weather data web service [MAD-127]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
             <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/postman_tests/MaDiPHS Weather API tests.postman_collection.json
+++ b/postman_tests/MaDiPHS Weather API tests.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "076479f6-dc1c-4865-b48f-0a120d872cc3",
-		"name": "MaDiPHS Weather API tests",
+		"_postman_id": "30717fdd-dfb9-49a7-8e53-7c6cd6d41120",
+		"name": "MaDiPHS Weather API tests ORIGINAL",
 		"description": "This is the test suite for the IPM Decisions Weather API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5789128"
+		"_exporter_id": "3222856"
 	},
 	"item": [
 		{
@@ -524,9 +524,9 @@
 							]
 						},
 						"url": {
-							"raw": "{{madiphs_wx_url}}/rest/weatheradapter/tahmo",
+							"raw": "{{wx_url}}/rest/weatheradapter/tahmo",
 							"host": [
-								"{{madiphs_wx_url}}"
+								"{{wx_url}}"
 							],
 							"path": [
 								"rest",

--- a/src/main/java/net/ipmdecisions/weather/services/WeatherAdapterService.java
+++ b/src/main/java/net/ipmdecisions/weather/services/WeatherAdapterService.java
@@ -571,7 +571,6 @@ public class WeatherAdapterService {
         if(secretKey == null || validUserName == null || tahmoUserName == null || tahmoPassword == null) {
             return Response.serverError().entity("Web service is missing required configuration").build();
         }
-
         String userName, password;
         // If credentials are given, use them for authentication
         if(credentials != null && !credentials.trim().isEmpty()) {
@@ -581,7 +580,7 @@ public class WeatherAdapterService {
                 password = node.get(PARAM_PASSWORD).asText();
             } catch (JsonProcessingException jpe) {
                 LOGGER.error("Unable to parse credentials", jpe);
-                return Response.status(Status.BAD_REQUEST).entity("Unable to parse credentials").build();
+                return Response.status(Status.UNAUTHORIZED).entity("Unable to parse credentials").build();
             }
         }
         // Validate token, set userName and password to values from environment variables
@@ -595,19 +594,19 @@ public class WeatherAdapterService {
                     password = tahmoPassword;
                 } else {
                     LOGGER.error("'{}' is not a valid username", decodedClaim);
-                    return Response.status(Status.BAD_REQUEST).entity("Token does not contain a valid username").build();
+                    return Response.status(Status.UNAUTHORIZED).entity("Token does not contain a valid username").build();
                 }
             } catch (TokenExpiredException tee) {
                 LOGGER.error("Given token has expired", tee);
-                return Response.status(Status.BAD_REQUEST).entity(tee.getMessage()).build();
+                return Response.status(Status.UNAUTHORIZED).entity(tee.getMessage()).build();
             } catch (Exception e) {
                 LOGGER.error("Unable to decode or validate token", e);
-                return Response.status(Status.BAD_REQUEST).entity("Unable to decode or validate token").build();
+                return Response.status(Status.UNAUTHORIZED).entity("Unable to decode or validate token").build();
             }
         }
         else {
             LOGGER.error("Credentials and token missing from request");
-            return Response.status(Status.BAD_REQUEST).entity("Credentials or token must be provided").build();
+            return Response.status(Status.UNAUTHORIZED).entity("Credentials or token must be provided").build();
         }
 
         if (!logInterval.equals(3600)) {

--- a/src/main/java/net/ipmdecisions/weather/services/WeatherAdapterService.java
+++ b/src/main/java/net/ipmdecisions/weather/services/WeatherAdapterService.java
@@ -19,6 +19,10 @@
 
 package net.ipmdecisions.weather.services;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,13 +37,8 @@ import java.util.Set;
 import java.util.Date;
 import java.util.stream.Collectors;
 import javax.ejb.EJB;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -83,6 +82,10 @@ public class WeatherAdapterService {
     private static final String PARAM_PASSWORD = "password";
 
     private WeatherDataUtil weatherDataUtil;
+
+    private static final Algorithm jwtAlgorithm = Algorithm.HMAC256(System.getenv("TOKEN_SECRET_KEY"));
+    public static final String TAHMO_TOKEN_ISSUER = "MaDiPHS";
+    public static final String TAHMO_TOKEN_CLAIM = "userId";
 
     @EJB
     private WeatherDataSourceBean weatherDataSourceBean;
@@ -532,6 +535,7 @@ public class WeatherAdapterService {
      * @param parameters   Comma separated list of the requested weather parameters, given by <a href="/rest/parameter" target="new">their codes</a>
      * @param ignoreErrors Set to "true" if you want the service to return weather data regardless of there being errors in the service. Currently not in use.
      * @param credentials  json object with "userName" and "password" properties set
+     * @param authHeader   if credentials are not given, a JSON Web Token (JWT) can be used instead
      * @return weather data for the requested weather station and time period
      * @requestExample application/x-www-form-urlencoded
      * weatherStationId:TA00321
@@ -554,22 +558,60 @@ public class WeatherAdapterService {
             @FormParam("interval") Integer logInterval,
             @FormParam("parameters") String parameters,
             @FormParam("ignoreErrors") String ignoreErrors,
-            @FormParam("credentials") String credentials
+            @FormParam("credentials") String credentials,
+            @HeaderParam(HttpHeaders.AUTHORIZATION) String authHeader
     ) {
         LOGGER.debug("Request Tahmo observations for weather station {}", stationCode);
 
-        if (!logInterval.equals(3600)) {
-            return Response.status(Status.BAD_REQUEST).entity("This service only provides hourly data").build();
+        // Verify that all necessary environment variables are set
+        String secretKey = System.getenv("TOKEN_SECRET_KEY");
+        String validUserName = System.getenv("TOKEN_USERNAME");
+        String tahmoUserName = System.getenv("TAHMO_USERNAME");
+        String tahmoPassword = System.getenv("TAHMO_PASSWORD");
+        if(secretKey == null || validUserName == null || tahmoUserName == null || tahmoPassword == null) {
+            return Response.serverError().entity("Web service is missing required configuration").build();
         }
 
         String userName, password;
-        try {
-            JsonNode node = new ObjectMapper().readTree(credentials);
-            userName = node.get(PARAM_USER_NAME).asText();
-            password = node.get(PARAM_PASSWORD).asText();
-        } catch (JsonProcessingException jpe) {
-            LOGGER.error("Unable to parse credentials", jpe);
-            return Response.status(Status.BAD_REQUEST).entity("Unable to parse credentials").build();
+        // If credentials are given, use them for authentication
+        if(credentials != null && !credentials.trim().isEmpty()) {
+            try {
+                JsonNode node = new ObjectMapper().readTree(credentials);
+                userName = node.get(PARAM_USER_NAME).asText();
+                password = node.get(PARAM_PASSWORD).asText();
+            } catch (JsonProcessingException jpe) {
+                LOGGER.error("Unable to parse credentials", jpe);
+                return Response.status(Status.BAD_REQUEST).entity("Unable to parse credentials").build();
+            }
+        }
+        // Validate token, set userName and password to values from environment variables
+        else if(authHeader != null && !authHeader.trim().isEmpty() && authHeader.startsWith("Bearer ")) {
+            try {
+                String token = authHeader.substring(7); // Remove "Bearer " prefix
+                DecodedJWT decodedJWT = JWT.require(jwtAlgorithm).withIssuer(TAHMO_TOKEN_ISSUER).build().verify(token);
+                String decodedClaim = decodedJWT.getClaim(TAHMO_TOKEN_CLAIM).asString();
+                if (validUserName.equals(decodedClaim)) {
+                    userName = tahmoUserName;
+                    password = tahmoPassword;
+                } else {
+                    LOGGER.error("'{}' is not a valid username", decodedClaim);
+                    return Response.status(Status.BAD_REQUEST).entity("Token does not contain a valid username").build();
+                }
+            } catch (TokenExpiredException tee) {
+                LOGGER.error("Given token has expired", tee);
+                return Response.status(Status.BAD_REQUEST).entity(tee.getMessage()).build();
+            } catch (Exception e) {
+                LOGGER.error("Unable to decode or validate token", e);
+                return Response.status(Status.BAD_REQUEST).entity("Unable to decode or validate token").build();
+            }
+        }
+        else {
+            LOGGER.error("Credentials and token missing from request");
+            return Response.status(Status.BAD_REQUEST).entity("Credentials or token must be provided").build();
+        }
+
+        if (!logInterval.equals(3600)) {
+            return Response.status(Status.BAD_REQUEST).entity("This service only provides hourly data").build();
         }
 
         String wds = "org.tahmo";

--- a/src/test/java/net/ipmdecisions/weather/datasourceadapters/TahmoAdapterTest.java
+++ b/src/test/java/net/ipmdecisions/weather/datasourceadapters/TahmoAdapterTest.java
@@ -12,16 +12,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Set;
+import java.util.UUID;
 
+import static net.ipmdecisions.weather.services.WeatherAdapterService.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 @ExtendWith(MockitoExtension.class)
 class TahmoAdapterTest {
 
@@ -49,6 +52,33 @@ class TahmoAdapterTest {
         tahmoConnection = Mockito.mock(TahmoAdapter.TahmoConnection.class);
         adapter = new TahmoAdapter(tahmoConnection);
     }
+
+    @Test
+    //@Disabled
+    /**
+     * Use this test method to generate JWT token for a user. Do not check username and secret key into source control!
+     * Username and secret key must be available for the application as environment variables: TOKEN_USERNAME and
+     * TOKEN_SECRET_KEY. If/when more users should be admitted, this test method should be converted to a script which
+     * generates token for a given username + expiry date, and persists valid usernames to a file for later
+     * verification. Check content of tokens here: https://jwt.io/
+     */
+    public void generateJwtToken() {
+        String secretKey = "ADD-SECRET-KEY-HERE";
+        Algorithm algorithm = Algorithm.HMAC256(secretKey);
+        long oneHundredAndEightyDays = 15552000000L;
+
+        String jwtToken = JWT.create()
+                .withIssuer(TAHMO_TOKEN_ISSUER) // the party that created the token and signed it
+                .withSubject("Tahmo Weather Data") // the subject of the JWT
+                .withClaim(TAHMO_TOKEN_CLAIM, "ADD-USERNAME-HERE")
+                .withIssuedAt(new Date()) //  the time at which the JWT was created
+                .withNotBefore(new Date()) // the time before which the JWT should not be accepted for processing
+                .withExpiresAt(new Date(System.currentTimeMillis() + oneHundredAndEightyDays)) // the expiration time
+                .withJWTId(UUID.randomUUID().toString()) // unique identifier for the JWT
+                .sign(algorithm);
+        System.out.println(jwtToken);
+    }
+
 
     @Test
     public void shouldReturnNullIfTahmoResponseIsEmpty() throws ParseWeatherDataException {


### PR DESCRIPTION
The goal is to enable temporary access for ICIPE, without disclosing NIBIOs credentials for communicating with Tahmo.
Solution includes disabled test method which can be used for generating new token. This test should be converted to a script or API endpoint if authentication method is to be made permanent and include more users. Make sure that token username and secret key used at token creation are equal to the values known by the server at runtime. 

The api endpoint `/MaDiPHSWeatherService/rest/weatheradapter/tahmo/` will first check for the existence of parameter `credentials`, and use this for authentication at Tahmo if given. If not, we check for the `Authorization` HTTP header. If token is approved, we use Tahmo credentials from environment variables TAHMO_USERNAME and TAHMO_PASSWORD.

This solution requires the existence of the following environment variables:
TOKEN_SECRET_KEY - used for creating + verifying tokens
TOKEN_USERNAME - the username contained in token, validated for each request
TAHMO_USERNAME - nibios username when communicating with tahmo
TAHMO_PASSWORD - nibios password when communicating with tahmo
